### PR TITLE
feat: sync Prompt profiles

### DIFF
--- a/blincus
+++ b/blincus
@@ -769,6 +769,156 @@ config_save() {
   ini_save "$CONFIG_FILE"
 }
 
+prompt_create_profile() {
+    # create a Prompt profile using dconf given the guid of the instance
+    # $1 = guid
+    # $2 = name
+
+    # dconf read /org/gnome/Prompt/Profiles/d092b3519698570a3252762c658f7629/
+    # /org/gnome/Prompt/Profiles/d092b3519698570a3252762c658f7629/custom-command
+
+    #   'blincus shell myubuntu'
+    # /org/gnome/Prompt/Profiles/d092b3519698570a3252762c658f7629/label
+
+    #   'myubuntu'
+    # /org/gnome/Prompt/Profiles/d092b3519698570a3252762c658f7629/login-shell
+
+    #   true
+    # /org/gnome/Prompt/Profiles/d092b3519698570a3252762c658f7629/use-custom-command
+
+    #   true
+
+    # if dconf doesn't exist, just return
+    if ! command -v dconf >/dev/null; then
+        return
+    fi
+
+    local guid=$1
+    local name=$2
+
+    local profile="/org/gnome/Prompt/Profiles/${guid}/"
+
+    dconf write "${profile}custom-command" "'blincus shell ${name}'"
+    dconf write "${profile}label" "'${name}'"
+    dconf write "${profile}login-shell" "true"
+    dconf write "${profile}use-custom-command" "true"
+
+    prompt_add_profile "$guid"
+
+}
+
+prompt_add_profile(){
+    # Read the current value of the array
+    CURRENT_VALUE=$(dconf read /org/gnome/Prompt/profile-uuids)
+    local guid=$1
+
+    # remove the leading and trailing brackets
+    CURRENT_VALUE=${CURRENT_VALUE:1:-1}
+
+    # remove any spaces
+
+    CURRENT_VALUE=${CURRENT_VALUE// /}
+
+    # split the string into an array
+    IFS=',' read -r -a array <<< "$CURRENT_VALUE"
+
+    # add the new value
+    array+=("'$guid'")
+
+    # join the array back into a string
+    UPDATED_VALUE=$(printf "%s," "${array[@]}")
+
+    # remove the trailing comma
+    UPDATED_VALUE=${UPDATED_VALUE%?}
+
+    # add the leading and trailing brackets
+    UPDATED_VALUE="[$UPDATED_VALUE]"
+
+    # Write the updated array back to dconf
+    dconf write /org/gnome/Prompt/profile-uuids "$UPDATED_VALUE"
+
+}
+
+prompt_reconcile() {
+    # ensure that the prompt profiles for deleted instances are removed
+
+    # if dconf doesn't exist, just return
+    if ! command -v dconf >/dev/null; then
+        return
+    fi
+
+    # Read the current value of the array
+    CURRENT_VALUE=$(dconf read /org/gnome/Prompt/profile-uuids)
+
+    # remove the leading and trailing brackets
+    CURRENT_VALUE=${CURRENT_VALUE:1:-1}
+
+    # remove any spaces
+    CURRENT_VALUE=${CURRENT_VALUE// /}
+
+    # split the string into an array
+    IFS=',' read -r -a array <<< "$CURRENT_VALUE"
+
+    # loop through the array and remove any that don't exist
+    for i in "${!array[@]}"; do
+        guid=${array[i]}
+
+        # remove single quotes from guid
+
+        guid=${guid//\'/}
+
+        #echo "Checking profile for $(red $guid)"
+        local profile="/org/gnome/Prompt/Profiles/${guid}/"
+
+        custom_shell=$(dconf read "${profile}custom-command")
+
+        if [[ $custom_shell == *"blincus"* ]]; then
+            #echo "Profile $(red $guid) is a Blincus profile"
+            #echo "Custom shell: $custom_shell"
+
+            # check if the instance exists
+            local name=$(dconf read "${profile}label")
+            name=${name//\'/}
+            #echo --"$name"--
+            #echo "Profile $(red $guid) is for instance $(red $name)"
+            if ! incus list | grep -qw "$name"; then
+                #echo "Instance $(red $name) does not exist. Removing profile $(red $guid)"
+                # remove the profile
+                dconf reset -f "${profile}"
+                # remove the guid from the array
+                unset 'array[i]'
+                    # join the array back into a string
+                UPDATED_VALUE=$(printf "%s," "${array[@]}")
+
+                # remove the trailing comma
+                UPDATED_VALUE=${UPDATED_VALUE%?}
+
+                # add the leading and trailing brackets
+                UPDATED_VALUE="[$UPDATED_VALUE]"
+
+                #echo "UPDATED_VALUE: $UPDATED_VALUE"
+
+                # Write the updated array back to dconf
+                dconf write /org/gnome/Prompt/profile-uuids "$UPDATED_VALUE"
+            fi
+
+        fi
+
+    done
+
+    for image in $(blincus_instances); do
+            local iprofile="/org/gnome/Prompt/Profiles/${image}/"
+            icustom_shell=$(dconf read "${iprofile}custom-command")
+            if [ -z "$icustom_shell" ]
+            then
+
+                prompt_create_profile "$image" "$(blincus_instance_name "$image")"
+            fi
+
+    done
+
+}
+
 write_defaults() {
 
   # default container engine
@@ -800,6 +950,15 @@ write_defaults() {
   config_set "nix.scripts" "nix"
   # todo: flag or JIT set this
   # xhost +
+}
+
+blincus_instances() {
+    incus ls --format json |  jq -r '.[] | select(.config."user.blincusuid" != null) | .config."user.blincusuid"'
+}
+
+blincus_instance_name() {
+    local guid=$1
+    incus ls --format json |  jq -r '.[] | select(.config."user.blincusuid" == "'"$guid"'") | .name'
 }
 
 ini_load() {
@@ -947,6 +1106,10 @@ if (( errors > 0 )); then
 fi
 }
 
+uuid() {
+    uuidgen | sed 's/-//g'
+}
+
 blincus_config_set_command() {
   # Using the standard library (lib/config.sh) to store a value to the config
   config_set "${args[key]}" "${args[value]}"
@@ -1011,6 +1174,11 @@ blincus_launch_command() {
   echo "cat /etc/blincus" > $MOTDPROFILE
 
   incus file push $MOTDPROFILE "$name"/etc/profile.d/02-blincus.sh
+  guid=$(uuid)
+  echo "Blincus ID: $(yellow $guid)"
+  incus config set "$name"  user.blincusuid=$guid
+
+  prompt_create_profile "$guid" "$name"
 
   # mount $HOME at $HOME/host
 
@@ -2175,7 +2343,7 @@ blincus_custom_image_list_parse_requirements() {
 }
 
 initialize() {
-  version="0.2.0"
+  version="0.2.1"
   long_usage=''
   set -e
 
@@ -2191,6 +2359,7 @@ initialize() {
   fi
   sanity
   personalize
+  prompt_reconcile
 }
 
 run() {

--- a/install
+++ b/install
@@ -3,7 +3,7 @@
 
 next=0
 verbose=0
-version=0.2.0
+version=0.2.1
 
 # Print usage to stdout.
 # Arguments:

--- a/site/src/content/docs/cli/index.md
+++ b/site/src/content/docs/cli/index.md
@@ -15,7 +15,7 @@ in blincus will pass through to `incus`.
 
 | Attributes       | &nbsp;
 |------------------|-------------
-| Version:         | 0.2.0
+| Version:         | 0.2.1
 | Extensible:      | incus
 
 ## Usage

--- a/src/bashly.yml
+++ b/src/bashly.yml
@@ -4,7 +4,7 @@ help: |
   
   Wraps the `incus` command, so commands not implemented 
   in blincus will pass through to `incus`.
-version: 0.2.0
+version: 0.2.1
 extensible: incus
 footer: |
   View documentation online at https://blincus.dev

--- a/src/initialize.sh
+++ b/src/initialize.sh
@@ -9,3 +9,4 @@ if ! test -f "${CONFIG_FILE:-}"; then
 fi
 sanity
 personalize
+prompt_reconcile

--- a/src/launch_command.sh
+++ b/src/launch_command.sh
@@ -42,7 +42,11 @@ MOTDPROFILE=$(mktemp)
 echo "cat /etc/blincus" > $MOTDPROFILE
 
 incus file push $MOTDPROFILE "$name"/etc/profile.d/02-blincus.sh
+guid=$(uuid)
+echo "Blincus ID: $(yellow $guid)"
+incus config set "$name"  user.blincusuid=$guid
 
+prompt_create_profile "$guid" "$name"
 
 # mount $HOME at $HOME/host
 

--- a/src/lib/dconfig.sh
+++ b/src/lib/dconfig.sh
@@ -1,0 +1,145 @@
+prompt_create_profile() {
+    # create a Prompt profile using dconf given the guid of the instance
+    # $1 = guid
+    # $2 = name
+
+    # dconf read /org/gnome/Prompt/Profiles/d092b3519698570a3252762c658f7629/
+    # /org/gnome/Prompt/Profiles/d092b3519698570a3252762c658f7629/custom-command 
+    #   'blincus shell myubuntu'
+    # /org/gnome/Prompt/Profiles/d092b3519698570a3252762c658f7629/label 
+    #   'myubuntu'
+    # /org/gnome/Prompt/Profiles/d092b3519698570a3252762c658f7629/login-shell 
+    #   true
+    # /org/gnome/Prompt/Profiles/d092b3519698570a3252762c658f7629/use-custom-command 
+    #   true
+
+    # if dconf doesn't exist, just return
+    if ! command -v dconf >/dev/null; then
+        return
+    fi
+
+    local guid=$1
+    local name=$2
+
+    local profile="/org/gnome/Prompt/Profiles/${guid}/"
+
+    dconf write "${profile}custom-command" "'blincus shell ${name}'"
+    dconf write "${profile}label" "'${name}'"
+    dconf write "${profile}login-shell" "true"
+    dconf write "${profile}use-custom-command" "true"
+
+    prompt_add_profile "$guid"
+
+}
+
+prompt_add_profile(){
+    # Read the current value of the array
+    CURRENT_VALUE=$(dconf read /org/gnome/Prompt/profile-uuids)
+    local guid=$1
+
+    # remove the leading and trailing brackets
+    CURRENT_VALUE=${CURRENT_VALUE:1:-1}
+
+    # remove any spaces 
+    CURRENT_VALUE=${CURRENT_VALUE// /}
+
+    # split the string into an array
+    IFS=',' read -r -a array <<< "$CURRENT_VALUE"
+
+    # add the new value
+    array+=("'$guid'")
+
+    # join the array back into a string
+    UPDATED_VALUE=$(printf "%s," "${array[@]}")
+
+    # remove the trailing comma
+    UPDATED_VALUE=${UPDATED_VALUE%?}
+
+    # add the leading and trailing brackets
+    UPDATED_VALUE="[$UPDATED_VALUE]"
+
+
+    # Write the updated array back to dconf
+    dconf write /org/gnome/Prompt/profile-uuids "$UPDATED_VALUE"
+
+}
+
+prompt_reconcile() {
+    # ensure that the prompt profiles for deleted instances are removed
+
+    # if dconf doesn't exist, just return
+    if ! command -v dconf >/dev/null; then
+        return
+    fi
+
+    # Read the current value of the array
+    CURRENT_VALUE=$(dconf read /org/gnome/Prompt/profile-uuids)
+
+    # remove the leading and trailing brackets
+    CURRENT_VALUE=${CURRENT_VALUE:1:-1}
+
+    # remove any spaces
+    CURRENT_VALUE=${CURRENT_VALUE// /}
+
+    # split the string into an array
+    IFS=',' read -r -a array <<< "$CURRENT_VALUE"
+
+    # loop through the array and remove any that don't exist
+    for i in "${!array[@]}"; do
+        guid=${array[i]}
+
+        # remove single quotes from guid
+
+        guid=${guid//\'/}
+
+        #echo "Checking profile for $(red $guid)"
+        local profile="/org/gnome/Prompt/Profiles/${guid}/"
+
+        custom_shell=$(dconf read "${profile}custom-command")
+
+        if [[ $custom_shell == *"blincus"* ]]; then
+            #echo "Profile $(red $guid) is a Blincus profile"
+            #echo "Custom shell: $custom_shell"
+
+            # check if the instance exists
+            local name=$(dconf read "${profile}label")
+            name=${name//\'/}
+            #echo --"$name"--
+            #echo "Profile $(red $guid) is for instance $(red $name)"
+            if ! incus list | grep -qw "$name"; then
+                #echo "Instance $(red $name) does not exist. Removing profile $(red $guid)"
+                # remove the profile
+                dconf reset -f "${profile}"
+                # remove the guid from the array
+                unset 'array[i]'
+                    # join the array back into a string
+                UPDATED_VALUE=$(printf "%s," "${array[@]}")
+
+                # remove the trailing comma
+                UPDATED_VALUE=${UPDATED_VALUE%?}
+
+                # add the leading and trailing brackets
+                UPDATED_VALUE="[$UPDATED_VALUE]"
+
+                #echo "UPDATED_VALUE: $UPDATED_VALUE"
+
+                # Write the updated array back to dconf
+                dconf write /org/gnome/Prompt/profile-uuids "$UPDATED_VALUE"
+            fi
+
+        fi
+
+    done
+
+    for image in $(blincus_instances); do
+            local iprofile="/org/gnome/Prompt/Profiles/${image}/"
+            icustom_shell=$(dconf read "${iprofile}custom-command")
+            if [ -z "$icustom_shell" ]
+            then        
+                prompt_create_profile "$image" "$(blincus_instance_name "$image")"
+            fi
+
+    done
+
+
+}

--- a/src/lib/incus.sh
+++ b/src/lib/incus.sh
@@ -1,0 +1,8 @@
+blincus_instances() {
+    incus ls --format json |  jq -r '.[] | select(.config."user.blincusuid" != null) | .config."user.blincusuid"'
+}
+
+blincus_instance_name() {
+    local guid=$1
+    incus ls --format json |  jq -r '.[] | select(.config."user.blincusuid" == "'"$guid"'") | .name'
+}

--- a/src/lib/uuid.sh
+++ b/src/lib/uuid.sh
@@ -1,0 +1,3 @@
+uuid() {
+    uuidgen | sed 's/-//g'
+}


### PR DESCRIPTION
If Prompt terminal is installed, blincus will add custom profiles for blincus instances and reconcile them on each `blincus` command run.